### PR TITLE
fix: prevent drawer overlaying header

### DIFF
--- a/src/app/features/dynamic-drawer/dynamic-drawer.component.ts
+++ b/src/app/features/dynamic-drawer/dynamic-drawer.component.ts
@@ -53,13 +53,15 @@ import { DrawerConfig, DrawerService } from '@shell/drawer/drawer.service';
       left: 0;
       right: 0;
       bottom: 0;
-      z-index: 1000;
+      z-index: 40; /* sotto l'header (z-50) */
       pointer-events: none;
     }
 
     .dynamic-drawer {
       pointer-events: auto;
       max-width: 90vw;
+      background: white;
+      box-shadow: -2px 0 8px rgba(0,0,0,0.15);
     }
 
     .drawer-header {

--- a/src/styles.css
+++ b/src/styles.css
@@ -105,18 +105,3 @@ app-root {
   text-align: center;
   font-weight: 500;
 }
-
-mat-drawer-container {
-  position: fixed !important;
-  inset: 0 !important;
-  z-index: 9999 !important;
-  height: 100vh !important;
-  pointer-events: none; /* per non interferire col contenuto */
-}
-
-mat-drawer {
-  pointer-events: auto;
-  background: white;
-  box-shadow: -2px 0 8px rgba(0,0,0,0.15);
-  
-}


### PR DESCRIPTION
## Summary
- avoid global mat-drawer styles overriding layout
- place dynamic drawer below header and keep drawer styling local

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Found 1 load error)*

------
https://chatgpt.com/codex/tasks/task_e_6899f7e201648333a6f1ab2a06c27ad4