### PR TITLE
feat: improve checkout layout

### DIFF
--- a/src/app/pages/checkout/checkout.component.html
+++ b/src/app/pages/checkout/checkout.component.html
@@ -1,25 +1,58 @@
 <section class="container mx-auto p-4" *ngIf="cart?.items?.length; else emptyCart">
-  <h2 class="text-2xl font-semibold mb-4">Checkout</h2>
+  <div class="grid md:grid-cols-2 gap-8">
+    <form (ngSubmit)="submitOrder()" #f="ngForm" class="space-y-4">
+      <h2 class="text-2xl font-semibold mb-4">Informazioni di contatto</h2>
+      <p class="text-sm text-gray-600">Utilizzeremo questa email per inviare i dettagli e gli aggiornamenti relativi al tuo ordine.</p>
+      <div>
+        <label class="block mb-1">Indirizzo email</label>
+        <input type="email" name="email" [(ngModel)]="customer.email" readonly required class="w-full border rounded p-2 bg-gray-100" />
+      </div>
+      <div class="flex items-start">
+        <input type="checkbox" id="newsletter" name="newsletter" [(ngModel)]="newsletter" class="mr-2 mt-1">
+        <label for="newsletter" class="text-sm">
+          Rimani aggiornato senza spam! Iscriviti alla nostra newsletter. I dati saranno trattati secondo la Privacy Policy. (facoltativo)
+        </label>
+      </div>
 
-  <form (ngSubmit)="submitOrder()" #f="ngForm" class="grid gap-4 max-w-lg">
-    <div>
-      <label class="block mb-1">Nome</label>
-      <input type="text" name="name" [(ngModel)]="customer.name" required class="w-full border rounded p-2" />
-    </div>
-    <div>
-      <label class="block mb-1">Indirizzo</label>
-      <input type="text" name="address" [(ngModel)]="customer.address" required class="w-full border rounded p-2" />
-    </div>
-    <div>
-      <label class="block mb-1">Email</label>
-      <input type="email" name="email" [(ngModel)]="customer.email" required class="w-full border rounded p-2" />
-    </div>
+      <h3 class="text-xl font-semibold mt-6">Opzioni di pagamento</h3>
+      <div class="border rounded p-4">
+        <p class="font-medium mb-1">Bonifico bancario</p>
+        <p class="text-sm text-gray-600">Effettua il pagamento tramite bonifico bancario. Usa l'ID dell'ordine come causale. Il tuo ordine non verrà spedito finché i fondi non risulteranno trasferiti nel nostro conto corrente.</p>
+      </div>
 
-    <p class="font-bold mt-4">Totale: {{ cart.total_raw | currency:'EUR' }}</p>
-    <button type="submit" [disabled]="f.invalid" class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">
-      Conferma e paga
-    </button>
-  </form>
+      <div class="flex items-start">
+        <input type="checkbox" id="terms" name="terms" [(ngModel)]="acceptTerms" required class="mr-2 mt-1">
+        <label for="terms" class="text-sm">
+          Devi accettare Termini e condizioni e Informativa sulla privacy per continuare con l'acquisto.
+        </label>
+      </div>
+
+      <div class="flex justify-between mt-4">
+        <a routerLink="/cart" class="text-blue-600 hover:underline">Torna al carrello</a>
+        <button type="submit" [disabled]="f.invalid || !acceptTerms" class="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700">Effettua ordine</button>
+      </div>
+    </form>
+
+    <div>
+      <h2 class="text-2xl font-semibold mb-4">Riepilogo dell'ordine</h2>
+      <div *ngFor="let item of cart.items" class="mb-4 border-b pb-4">
+        <div class="flex justify-between">
+          <span>{{ item.quantity }}x {{ item.name }}</span>
+          <span>{{ (item.subtotal_raw / item.quantity) | currency:'EUR' }}</span>
+        </div>
+        <p class="text-sm text-gray-600">Prezzo totale per {{ item.quantity }} {{ item.name }} elemento{{ item.quantity > 1 ? 'i' : '' }}: {{ item.subtotal_raw | currency:'EUR' }}</p>
+      </div>
+      <a class="text-blue-600 hover:underline cursor-pointer">Aggiungi codici promozionali</a>
+      <div class="flex justify-between mt-4">
+        <span>Subtotale</span>
+        <span>{{ cart.total_raw | currency:'EUR' }}</span>
+      </div>
+      <div class="flex justify-between font-bold mt-2">
+        <span>Totale</span>
+        <span>{{ cart.total_raw | currency:'EUR' }}</span>
+      </div>
+    </div>
+  </div>
 </section>
 
 <ng-template #emptyCart>

--- a/src/app/pages/checkout/checkout.component.ts
+++ b/src/app/pages/checkout/checkout.component.ts
@@ -4,6 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Cart, CartService } from '../../services/cart.service';
 import { ToastService } from '../../services/common/toast.service';
+import { AuthService } from '../../core/services/auth.service';
 
 @Component({
   selector: 'app-checkout',
@@ -13,20 +14,27 @@ import { ToastService } from '../../services/common/toast.service';
 })
 export class CheckoutComponent implements OnInit {
   cart: Cart | null = null;
-  customer = { name: '', address: '', email: '' };
+  customer = { email: '' };
+  newsletter = false;
+  acceptTerms = false;
 
   constructor(
     private cartService: CartService,
     private toast: ToastService,
-    private router: Router
+    private router: Router,
+    private auth: AuthService
   ) {}
 
   ngOnInit(): void {
     this.cartService.get().subscribe(c => (this.cart = c));
+    const userInfo = this.auth.getUserInfo();
+    if (userInfo?.email) {
+      this.customer.email = userInfo.email;
+    }
   }
 
   submitOrder(): void {
-    this.cartService.checkout({ customer: this.customer }).subscribe({
+    this.cartService.checkout({ customer: this.customer, newsletter: this.newsletter }).subscribe({
       next: () => {
         this.toast.success('Ordine completato con successo');
         this.router.navigate(['/home']);


### PR DESCRIPTION
## Summary
- redesign checkout into two columns with contact info and payment on the left and order summary on the right
- prefill buyer email from login token and include newsletter opt-in and terms acceptance

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*
- `apt-get update && apt-get install -y chromium-browser` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ae2d577d88333997dabd9f5172d81